### PR TITLE
Confine requested attributes

### DIFF
--- a/lib/hiera/backend/ldap_backend.rb
+++ b/lib/hiera/backend/ldap_backend.rb
@@ -50,7 +50,7 @@ class Hiera
           begin
             filter = Net::LDAP::Filter.from_rfc4515(key)
             treebase = conf[:base]
-            searchresult = @connection.search(:filter => filter)
+            searchresult = @connection.search(:filter => filter, :attributes => conf[:attributes])
 
             for i in 0..searchresult.length-1 do
               answer[i] = {}


### PR DESCRIPTION
Added hiera.yaml variable to confine the requested attributes. Requesting all attributes can lead to "invalid byte sequence in UTF-8" errors and therefore not returning the whole dataset. That's for example the case for the usercertificate field in Active Directories.
