### PR TITLE
Changes LDAP exception catching to warning

### DIFF
--- a/lib/hiera/backend/ldap_backend.rb
+++ b/lib/hiera/backend/ldap_backend.rb
@@ -64,7 +64,7 @@ class Hiera
               end
             end
           rescue Exception => e
-            Hiera.debug("Exception: #{e}")
+            Hiera.warning("Exception: #{e}")
           end
           Hiera.debug(answer)
 


### PR DESCRIPTION
It makes sense to bubble up LDAP errors to the users as warnings rather than debug messages: you probably want to be alerted to when things go wrong in LDAP